### PR TITLE
fix: action to pull

### DIFF
--- a/.github/workflows/postman-newman.yml
+++ b/.github/workflows/postman-newman.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by specifying that the workflow should also run on pull requests targeting the `main` and `master` branches.